### PR TITLE
fix mixed content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![http://linuxserver.io](http://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
+![https://linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
 
 ### This container is not aimed at public consumption. It exists to serve as a single endpoint for LinuxServer.io containers and is based upon [Phusion](https://github.com/phusion/baseimage-docker).
 


### PR DESCRIPTION
Since the images are loaded on docker hub without going through a proxy like Github does the images were being loaded over http causing mixed content.
